### PR TITLE
Fix CRC calculation during code generation

### DIFF
--- a/buildSrc/src/main/java/io/dronefleet/mavlink/generator/FieldGenerator.java
+++ b/buildSrc/src/main/java/io/dronefleet/mavlink/generator/FieldGenerator.java
@@ -73,6 +73,10 @@ public class FieldGenerator implements Comparable<FieldGenerator> {
         return arraySize;
     }
 
+    public boolean isExtension() {
+        return extension;
+    }
+
     public TypeName javaType() {
         if (enumName != null) {
             return enumType();

--- a/buildSrc/src/main/java/io/dronefleet/mavlink/generator/MessageGenerator.java
+++ b/buildSrc/src/main/java/io/dronefleet/mavlink/generator/MessageGenerator.java
@@ -67,6 +67,7 @@ public class MessageGenerator {
         crc.accumulate(name + " ");
         fields.stream()
                 .sorted()
+                .filter(f -> !f.isExtension())
                 .peek(f -> crc.accumulate(f.getType() + " "))
                 .peek(f -> crc.accumulate(f.getName() + " "))
                 .filter(FieldGenerator::isArray)


### PR DESCRIPTION
At the moment the CRC_EXTRA calculation is wrong, if the message contains extension fields. These must not be considered according to https://mavlink.io/en/guide/serialization.html. 

For example CRC_EXTRA for message MissionCount must be 221 not 52 (as it is now in java-gen).

