### PR TITLE
Fix heatbeat nullpointer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,8 +109,14 @@ gradle-app.setting
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
 
+# Eclipse
+**/.settings
+**/.classpath
+**/.project
+**/.gitignore
 
 # GPG
 secring.gpg
 
 # End of https://www.gitignore.io/api/java,gradle,intellij+all
+/bin/

--- a/src/main/java/io/dronefleet/mavlink/MavlinkConnection.java
+++ b/src/main/java/io/dronefleet/mavlink/MavlinkConnection.java
@@ -275,7 +275,7 @@ public class MavlinkConnection {
             // for this system.
             if (payload instanceof Heartbeat) {
                 Heartbeat heartbeat = (Heartbeat) payload;
-                if (dialects.containsKey(heartbeat.autopilot().entry())) {
+                if (heartbeat.autopilot() != null && dialects.containsKey(heartbeat.autopilot().entry())) {
                     systemDialects.put(packet.getSystemId(), dialects.get(heartbeat.autopilot().entry()));
                 }
             }


### PR DESCRIPTION
While running ArduRover 3.4.2 with Raspberry Pi as companion program connected to MAVLink via mavlink-router, I found that "heartbeat.autopilot()" returned null, which caused a null pointer exception in the code. 