### PR TITLE
Fixed primitive array parsing

### DIFF
--- a/buildSrc/src/main/java/io/dronefleet/mavlink/generator/FieldGenerator.java
+++ b/buildSrc/src/main/java/io/dronefleet/mavlink/generator/FieldGenerator.java
@@ -216,8 +216,17 @@ public class FieldGenerator implements Comparable<FieldGenerator> {
         if ("char".equals(type)) {
             return ClassName.get(String.class);
         }
-        if ("uint8_t".equals(type)) {
+        if ("uint8_t".equals(type) || "int8_t".equals(type)) {
             return TypeName.get(byte[].class);
+        }
+        if ("uint16_t".equals(type) || "int16_t".equals(type)) {
+            return TypeName.get(short[].class);
+        }
+        if ("uint32_t".equals(type) || "int32_t".equals(type)) {
+            return TypeName.get(int[].class);
+        }
+        if ("uint64_t".equals(type) || "int64_t".equals(type)) {
+            return TypeName.get(long[].class);
         }
         return ParameterizedTypeName.get(ClassName.get(List.class), primitiveType().box());
     }

--- a/src/main/java/io/dronefleet/mavlink/serialization/payload/reflection/ReflectionPayloadDeserializer.java
+++ b/src/main/java/io/dronefleet/mavlink/serialization/payload/reflection/ReflectionPayloadDeserializer.java
@@ -82,7 +82,13 @@ public class ReflectionPayloadDeserializer implements MavlinkPayloadDeserializer
                             } else if (String.class.isAssignableFrom(fieldType)) {
                                 method.invoke(builder, stringValue(data));
                             } else if (byte[].class.isAssignableFrom(fieldType)) {
-                                method.invoke(builder, data);
+                                method.invoke(builder, (Object) data);
+                            } else if (short[].class.isAssignableFrom(fieldType)) {
+                                method.invoke(builder, (Object) shortArrayValue(data));
+                            } else if (int[].class.isAssignableFrom(fieldType)) {
+                                method.invoke(builder, (Object) intArrayValue(data));
+                            } else if (long[].class.isAssignableFrom(fieldType)) {
+                                method.invoke(builder, (Object) longArrayValue(data));
                             } else if (BigInteger.class.isAssignableFrom(fieldType)) {
                                 method.invoke(builder, bigIntValue(data));
                             }
@@ -162,4 +168,28 @@ public class ReflectionPayloadDeserializer implements MavlinkPayloadDeserializer
                 (Class<? extends Enum>) enumType,
                 (int) integerValue(data, signed));
     }
+
+    private short[] shortArrayValue(byte[] data){
+        short[] result = new short[data.length/2];
+        ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).asShortBuffer().get(result);
+
+        return result;
+    }
+
+    private int[] intArrayValue(byte[] data){
+        int[] result = new int[data.length/4];
+        ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer().get(result);
+
+        return result;
+    }
+
+
+    private long[] longArrayValue(byte[] data){
+        long[] result = new long[data.length/8];
+        ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).asLongBuffer().get(result);
+
+        return result;
+    }
+
+
 }


### PR DESCRIPTION
Suggested fix for https://github.com/dronefleet/mavlink/issues/47

Change the field type from `List` to the primitive array type of the corresponding size.
One wrinkle in this is that the user will need to use e.g. `Short.toUnsignedInt(short)` to correctly retrieve values from the array.